### PR TITLE
fix: incorrect usage of `calc_seq_hits_misses_fas`

### DIFF
--- a/src/earthformer/metrics/sevir.py
+++ b/src/earthformer/metrics/sevir.py
@@ -141,7 +141,7 @@ class SEVIRSkillScore(Metric):
     def update(self, pred: torch.Tensor, target: torch.Tensor):
         pred, target = self.preprocess(pred, target)
         for i, threshold in enumerate(self.threshold_list):
-            hits, misses, fas = self.calc_seq_hits_misses_fas(target, pred, threshold)
+            hits, misses, fas = self.calc_seq_hits_misses_fas(pred, target, threshold)
             self.hits[i] += hits
             self.misses[i] += misses
             self.fas[i] += fas


### PR DESCRIPTION
*Issue #3*

Change the incorrect usage of `calc_seq_hits_misses_fas` from `hits, misses, fas = self.calc_seq_hits_misses_fas(target, pred, threshold)` to `hits, misses, fas = self.calc_seq_hits_misses_fas(pred, target, threshold)` in [the metrics used in SEVIR](https://github.com/amazon-research/earth-forecasting-transformer/blob/main/src/earthformer/metrics/sevir.py): https://github.com/amazon-research/earth-forecasting-transformer/blob/9c18c5a0be9c1af686827a191217a6cccf57812b/src/earthformer/metrics/sevir.py#L144
