### PR TITLE
fix: MAE calc in ENSO

### DIFF
--- a/scripts/cuboid_transformer/enso/train_cuboid_enso.py
+++ b/scripts/cuboid_transformer/enso/train_cuboid_enso.py
@@ -558,7 +558,7 @@ class CuboidENSOPLModule(pl.LightningModule):
 
     def test_epoch_end(self, outputs):
         test_mse = self.test_mse.compute()
-        test_mae = self.test_mse.compute()
+        test_mae = self.test_mae.compute()
         nino_preds_list, nino_target_list = map(list, zip(*outputs))
         nino_preds_list = torch.cat(nino_preds_list, dim=0)
         nino_target_list = torch.cat(nino_target_list, dim=0)


### PR DESCRIPTION
Fix `test_mae = self.test_mse.compute()` to `test_mae = self.test_mae.compute()` in https://github.com/amazon-research/earth-forecasting-transformer/blob/790791dcdc0f0c6ebcece08ea01141b4683a82d4/scripts/cuboid_transformer/enso/train_cuboid_enso.py#L561
